### PR TITLE
[功能相关]关于TechnoExt的扩展以及新的弹头逻辑

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -4236,6 +4236,8 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->LastTarget)
 
 		.Process(this->AddonAttachmentData)
+
+		.Process(this->Weapons)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -270,6 +270,9 @@ public:
 
 		std::vector<std::unique_ptr<TechnoTypeExt::ExtData::AttachmentDataEntry>> AddonAttachmentData;
 
+		// replace Weapons in TechnoTypeExt
+		PromotableVector<WeaponStruct> Weapons;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 		{ }
 

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -22,7 +22,19 @@ DEFINE_HOOK(0x70E140, TechnoClass_GetWeapon, 0x6)
 	auto pExt = TechnoExt::ExtMap.Find(pThis);
 	TechnoTypeClass* pType = pThis->GetTechnoType();
 	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-	const WeaponStruct* pWeapon = &pTypeExt->Weapons.Get(weaponIdx, pThis);
+
+	// get weapons data from pTypeExt
+	// a loooooooooooooooooot of logic needs revamping
+	if (pExt->Weapons.Get(weaponIdx, pThis).WeaponType == nullptr)
+	{
+		auto baseWeapon = pTypeExt->Weapons.Base;
+		auto verteranWeapon = pTypeExt->Weapons.Veteran;
+		auto eliteWeapon = pTypeExt->Weapons.Elite;
+		*&pExt->Weapons.Base = std::move(baseWeapon);
+		*&pExt->Weapons.Veteran = std::move(verteranWeapon);
+		*&pExt->Weapons.Elite = std::move(eliteWeapon);
+	}
+	const WeaponStruct* pWeapon = &pExt->Weapons.Get(weaponIdx, pThis);
 
 	if (pThis->WhatAmI() == AbstractType::Building && pType->Gunner)
 	{

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -11,6 +11,7 @@ DEFINE_HOOK(0x701900, TechnoClass_ReceiveDamage_BeforeAll, 0x6)
 	LEA_STACK(args_ReceiveDamage*, args, 0x4);
 
 	const auto pExt = TechnoExt::ExtMap.Find(pThis);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
 	const auto pWHExt = WarheadTypeExt::ExtMap.Find(args->WH);
 	bool attackedWeaponDisabled = false;
 
@@ -44,6 +45,21 @@ DEFINE_HOOK(0x701900, TechnoClass_ReceiveDamage_BeforeAll, 0x6)
 			}
 
 			*args->Damage = static_cast<int>(*args->Damage * damageMultiplier);
+		}
+
+		// TODO: New WeaponFLH? And ammo limit? And a looooooooot of logics
+		if (pWHExt->ReplaceTargetWeapon &&
+			pTypeExt->ReplaceWeaponAllow
+			)
+		{
+			if (pWHExt->ReplaceTargetWeaponTo != nullptr)
+			{
+				pThis->GetWeapon(0)->WeaponType = pWHExt->ReplaceTargetWeaponTo;
+			}
+			else if (pTypeExt->ReplaceWeaponInto != nullptr)
+			{
+				pThis->GetWeapon(0)->WeaponType = pTypeExt->ReplaceWeaponInto;
+			}
 		}
 
 		ShieldClass* const pShieldData = pExt->Shield.get();

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1596,6 +1596,10 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// OnFire 拓至所有单位类型
 	this->OnFire.Read(exINI, pSection, "OnFire");
 
+	// 武器替换弹头的效果
+	this->ReplaceWeaponAllow.Read(exINI, pSection, "ReplaceWeapon.Allow");
+	this->ReplaceWeaponInto.Read(exINI, pSection, "ReplaceWeapon.Into");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 	this->ImmuneToEMP.Read(exINI, pSection, "ImmuneToEMP");
@@ -2216,6 +2220,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DrainMoney_Display_Offset)
 
 		.Process(this->OnFire)
+
+		.Process(this->ReplaceWeaponAllow)
+		.Process(this->ReplaceWeaponInto)
 		;
 
 	Stm

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -565,6 +565,9 @@ public:
 		Valueable<bool> Parasite_NoRock;
 		ValueableVector<AttachEffectTypeClass*> Parasite_AttachEffects;
 
+		Valueable<bool> ReplaceWeaponAllow;
+		Nullable<WeaponTypeClass*> ReplaceWeaponInto;
+
 		//Ares
 		ValueableVector<TechnoTypeClass*> InitialPayload_Types;
 		ValueableVector<int> InitialPayload_Nums;
@@ -1063,6 +1066,9 @@ public:
 			, LimitedAttackRange { false }
 
 			, Explodes_KillPassengers{ true }
+
+			, ReplaceWeaponAllow { true }
+			, ReplaceWeaponInto { nullptr }
 
 			, TurretROT {}
 			, InitialPayload_Types {}

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -411,6 +411,9 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		AttachAttachment_IsOnTurrets.emplace_back(isonturret.Get());
 	}
 
+	this->ReplaceTargetWeapon.Read(exINI, pSection, "ReplaceTargetWeapon");
+	this->ReplaceTargetWeaponTo.Read(exINI, pSection, "ReplaceTargetWeapon.To");
+
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 	this->AffectsEnemies.Read(exINI, pSection, "AffectsEnemies");
@@ -731,6 +734,9 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttachAttachment_TechnoTypes)
 		.Process(this->AttachAttachment_FLHs)
 		.Process(this->AttachAttachment_IsOnTurrets)
+
+		.Process(this->ReplaceTargetWeapon)
+		.Process(this->ReplaceTargetWeaponTo)
 
 		// Ares tags
 		.Process(this->Verses)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -271,6 +271,9 @@ public:
 		std::vector<CoordStruct> AttachAttachment_FLHs;
 		std::vector<bool> AttachAttachment_IsOnTurrets;
 
+		Valueable<bool> ReplaceTargetWeapon;
+		Nullable<WeaponTypeClass*> ReplaceTargetWeaponTo;
+
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 		ValueableVector<double> Verses;
@@ -535,6 +538,9 @@ public:
 			, AttachAttachment_TechnoTypes {}
 			, AttachAttachment_FLHs {}
 			, AttachAttachment_IsOnTurrets {}
+
+			, ReplaceTargetWeapon { false }
+			, ReplaceTargetWeaponTo { nullptr }
 
 			, Verses(11)
 			, Versus {}

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -234,8 +234,6 @@ int ShieldClass::ReceiveDamage(args_ReceiveDamage* args)
 		this->Timers.SelfHealing.Start(rate); // when attacked, restart the timer
 		this->ResponseAttack();
 
-		this->ShieldStolen(args, shieldDamage);
-
 		if (pWHExt->DecloakDamagedTargets)
 			this->Techno->Uncloak(false);
 


### PR DESCRIPTION
做了以下工作：
1. 删除了`ShieldClass`中多余的一次护盾窃取逻辑
2. 给`TechnoExt`添加了`Weapons`成员，现在Hooks.Firing中`GetWeapon`逻辑返回的是当前单位的武器而非当前单位所属类型的武器，后面一大票逻辑没改所以可能有亿点点问题，后面修（
3. 新增 武器替换 弹头，目前仅针对主武器进行替换，并且FLH等等一大票东西没修（
```ini
[WarheadType]ReplaceTargetWeapon = <bool> ; 确认该弹头是否开启武器替换功能，默认为false
[WarheadType]ReplaceTargetWeapon.To = <WeaponType> ;弹头将把目标的主武器替换成该武器，这个的优先级要高于`ReplaceWeapon.Into`，默认为空 

[TechnoType]ReplaceWeapon.Allow = <bool> ; 是否允许该单位被替换武器，默认为true 
[TechnoType]ReplaceWeapon.Into = <WeaponType> ; 该单位受到武器替换弹头影响是，将把主武器替换成指定的武器，这个的优先级要低于'ReplaceWeapon.To'，默认为空 
```
当单位没有指定`ReplaceWeapon.Into`且弹头没有指定`ReplaceTargetWeapon.To`时，武器替换不生效。

<!-- Please add [Minor] to the title or the description if this change should not be mentioned in documentation, what's new and no credit needs to be given. -->
